### PR TITLE
Add the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 [Your Name]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Worklog Assistant is an open source replacement for the Worklog Assistant tool t
 - [Usage](#usage)
 - [Contribution Guidelines](#contribution-guidelines)
 - [External Resources](#external-resources)
+- [License](#license)
 
 ![worklog assistant image](docs/image.png)
 
@@ -85,3 +86,6 @@ The purpose of Worklog Assistant is to provide a reliable and efficient tool for
 - **Submit Worklogs**: Submit your tracked worklogs directly to JIRA with a single click.
 - **User-Friendly Interface**: View and manage your worklogs in an intuitive and easy-to-use interface.
 
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,3 +118,6 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+# License information
+license: MIT


### PR DESCRIPTION
Add the MIT license to the repository.

* **LICENSE file**
  - Add the MIT license text.

* **README.md**
  - Add a section mentioning the MIT license.

* **pubspec.yaml**
  - Add license information for MIT license.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/evolvedlight/WorklogAssistant?shareId=bf349cf8-90d8-45be-82f9-b401ca85f8c6).